### PR TITLE
Add an empty check before calling setColor

### DIFF
--- a/addon/mixins/col-pick.js
+++ b/addon/mixins/col-pick.js
@@ -39,8 +39,9 @@ export default Ember.Mixin.create( {
   }),
 
   valueDidChange: onRenderObserver('value', function() {
-    if (this._colpick) {
-      this._colpick.colpickSetColor(this.get('value'));
+    var value = this.get('value');
+    if (this._colpick && value) {
+      this._colpick.colpickSetColor(value);
     }
   }),
 


### PR DESCRIPTION
When the `value` field of a `col-pick` component is set to an empty (`null` or `undefined`) value, the colpick library throws an exception, which prevents propagation of Ember notifications.