### PR TITLE
Add option to use the hashtag

### DIFF
--- a/addon/mixins/col-pick.js
+++ b/addon/mixins/col-pick.js
@@ -30,6 +30,7 @@ export default Ember.Mixin.create( {
   flat: true, // [true/false] render as popup (true) rendering inline (false)
   value: null,
   previewValue: null,
+  useHashtag: false,
 
   _colpick: undefined,
 
@@ -56,6 +57,10 @@ export default Ember.Mixin.create( {
         submit: 0,
         flat: this.get('flat'),
         onChange: Ember.run.bind(this, function(hsb, hex, rgb, el, bySetColor) {
+          if (this.get('useHashtag')) {
+            hex = '#' + hex;
+          }
+          
           this.set('previewValue', hex);
 
           if (!bySetColor) {

--- a/tests/unit/components/col-pick-input-test.js
+++ b/tests/unit/components/col-pick-input-test.js
@@ -88,7 +88,7 @@ test("two way binding with colpick", function() {
   equal(style('.colpick_current_color', popup), 'background-color: rgb(255, 255, 255);');
 });
 
-test("correctly updates value with hashtag when set", function() {
+test("correctly updates value with hashtag when set", function(assert) {
   var component = this.subject({
     useHashtag: true
   });
@@ -99,7 +99,7 @@ test("correctly updates value with hashtag when set", function() {
   
   Ember.run(component, 'set', 'value', '#FFFFFF');
   
-  equal(Ember.run(component, 'get', 'previewValue'), '#ffffff');
-  equal(style('.colpick_new_color', popup), 'background-color: rgb(255, 255, 255);');
-  equal(style('.colpick_current_color', popup), 'background-color: rgb(255, 255, 255);');
+  assert.equal(Ember.run(component, 'get', 'previewValue'), '#ffffff');
+  assert.equal(style('.colpick_new_color', popup), 'background-color: rgb(255, 255, 255);');
+  assert.equal(style('.colpick_current_color', popup), 'background-color: rgb(255, 255, 255);');
 });

--- a/tests/unit/components/col-pick-input-test.js
+++ b/tests/unit/components/col-pick-input-test.js
@@ -87,3 +87,19 @@ test("two way binding with colpick", function() {
   equal(style('.colpick_new_color', popup), 'background-color: rgb(255, 255, 255);');
   equal(style('.colpick_current_color', popup), 'background-color: rgb(255, 255, 255);');
 });
+
+test("correctly updates value with hashtag when set", function() {
+  var component = this.subject({
+    useHashtag: true
+  });
+  
+  this.append();
+  
+  var popup = component.popup();
+  
+  Ember.run(component, 'set', 'value', '#FFFFFF');
+  
+  equal(Ember.run(component, 'get', 'previewValue'), '#ffffff');
+  equal(style('.colpick_new_color', popup), 'background-color: rgb(255, 255, 255);');
+  equal(style('.colpick_current_color', popup), 'background-color: rgb(255, 255, 255);');
+});


### PR DESCRIPTION
If the input contains the value '#000000', the colorpicker does understand that. But when changing the color, it will remove the hashtag in the inputfield. Added an option to be able to use/keep the hashtag.