### PR TITLE
Entering a valid hex code sets the color

### DIFF
--- a/addon/mixins/col-pick.js
+++ b/addon/mixins/col-pick.js
@@ -54,14 +54,14 @@ export default Ember.Mixin.create( {
         colorScheme: colorScheme,
         submit: 0,
         flat: this.get('flat'),
-        onChange: Ember.run.bind(this, function(hsb, hex, rgb, el, bySetColor) {
+        onChange: Ember.run.bind(this, function(hsb, hex) {
           if (this.get('useHashtag')) {
             hex = '#' + hex;
           }
           
           this.set('previewValue', hex);
 
-          if (!bySetColor) {
+          if (this._isValidPreviewValue()) {
             this.set('value', hex);
           }
         }),
@@ -82,6 +82,12 @@ export default Ember.Mixin.create( {
         colpick.colpickSetColor(value);
       }
     }
+  },
+
+  _isValidPreviewValue: function() {
+    var previewHex = this.get('previewValue');
+    var validityRegex = this.get('useHashtag') ? /^#[a-f0-9]{6}$/i : /^[a-f0-9]{6}$/i;
+    return Ember.isPresent(previewHex.match(validityRegex));
   },
 
   popup: function() {

--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.3.1",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.15",
-    "jquery": "^1.11.1",
+    "jquery": "1.11.1",
     "loader.js": "ember-cli/loader.js#3.2.0",
     "qunit": "~1.17.1"
   },

--- a/tests/unit/components/col-pick-test.js
+++ b/tests/unit/components/col-pick-test.js
@@ -79,3 +79,20 @@ test("correctly renders initial bound value", function(assert) {
   assert.equal(style('.colpick_new_color', popup), 'background-color: rgb(255, 255, 255);');
   assert.equal(style('.colpick_current_color', popup), 'background-color: rgb(255, 255, 255);');
 });
+
+test('sets the color only if a valid color is typed into the input', function(assert) {
+  var component = this.subject();
+  this.render();
+
+  component.popup();
+
+  Ember.run(function() {
+    component.$('.colpick_hex_field input').val('ff000').keyup();
+  });
+  assert.equal(component.get('value'), null, 'After receiving five hex characters we do not yet have a valid color to set');
+
+  Ember.run(function() {
+    component.$('.colpick_hex_field input').val('ff0000').keyup();
+  });
+  assert.equal(component.get('value'), 'ff0000', 'After receiving six hex characters the color is set');
+});


### PR DESCRIPTION
Either pasting a hex value or typing a hex-like value into the hex
input sets the preview value and the value.

Looks like this (first I type in two valid hex strings, then I paste in a valid hex string):

![entering-hex-sets-value](https://cloud.githubusercontent.com/assets/401983/11170509/a896b74a-8bce-11e5-87ad-09eeb36f9ff6.gif)
