### PR TITLE
Calling `this._super.included` with `apply` is required

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ module.exports = {
     return path.join(__dirname, 'blueprints');
   },
   included: function colpick_included(app) {
-    this._super.included(app);
+    this._super.included.apply(this, arguments);
 
     var colpickPath = path.join(app.bowerDirectory, 'colpick');
 


### PR DESCRIPTION
Calling `this._super.included` with `apply` is required: https://github.com/ember-cli/ember-cli/blob/v2.4.3/lib/models/addon.js#L342