### PR TITLE
Make fastboot guard

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,11 @@ module.exports = {
   },
   included: function colpick_included(app) {
     this._super.included.apply(this, arguments);
+    if(!process.env.EMBER_CLI_FASTBOOT) {
+      var colpickPath = path.join(app.bowerDirectory, 'colpick');
 
-    var colpickPath = path.join(app.bowerDirectory, 'colpick');
-
-    this.app.import(path.join(colpickPath, 'js',  'colpick.js'));
-    this.app.import(path.join(colpickPath, 'css', 'colpick.css'));
+      this.app.import(path.join(colpickPath, 'js',  'colpick.js'));
+      this.app.import(path.join(colpickPath, 'css', 'colpick.css'));
+    }
   }
 };


### PR DESCRIPTION
I implemented a simple fastboot guard so that the fastboot server can start and is not crashing while booting. I tried to implement a fixed base on the following discussions: ember-fastboot/ember-cli-fastboot#105 and plusacht/ember-bootstrap-datetimepicker#75