### PR TITLE
add compatibility for FastBoot >=1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,33 @@
 'use strict';
 var path = require('path');
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+var map = require('broccoli-stew').map;
 
 module.exports = {
   name: 'ember-colpick',
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
   },
+  treeForVendor(defaultTree) {
+    var trees = [];
+
+    if (defaultTree) {
+      trees.push(defaultTree);
+    }
+
+    var browserVendorLib = new Funnel(path.join(this.app.bowerDirectory, 'colpick', 'js'), {
+      files: ['colpick.js'],
+      destDir: 'colpick'
+    });
+
+    browserVendorLib = map(browserVendorLib, (content) => `if (typeof FastBoot === 'undefined') { ${content} }`);
+    trees.push(browserVendorLib);
+    return new mergeTrees(trees);
+  },
   included: function colpick_included(app) {
     this._super.included.apply(this, arguments);
-    if(!process.env.EMBER_CLI_FASTBOOT) {
-      var colpickPath = path.join(app.bowerDirectory, 'colpick');
-
-      this.app.import(path.join(colpickPath, 'js',  'colpick.js'));
-      this.app.import(path.join(colpickPath, 'css', 'colpick.css'));
-    }
+    this.app.import(path.join('vendor', 'colpick',  'colpick.js'));
+    this.app.import(path.join(app.bowerDirectory, 'colpick', 'css', 'colpick.css'));
   }
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.2",
+    "broccoli-funnel": "1.2.0",
+    "broccoli-merge-trees": "^2.0.0",
+    "broccoli-stew": "1.5.0",
     "ember-cli": "2.4.3",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-dependency-checker": "^1.2.0",


### PR DESCRIPTION
This takes care of #19 by using the new recommended patterns for selectively not eval'ing code that cannot run in server/FastBoot environments.