### PR TITLE
Add ember-cli version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,14 @@
 'use strict';
 const path = require('path');
+const VersionChecker = require('ember-cli-version-checker');
 
 module.exports = {
   name: 'ember-colpick',
+  init() {
+    this._super.init && this._super.init.apply(this, arguments);
+    let checker = new VersionChecker(this);
+    checker.for('ember-cli').assertAbove('2.15.0', 'ember-colpick >= 1.0.0 is only supported in ember-cli >= 2.15.0. To fix, either downgrade ember-colpick or upgrade ember-cli.');
+  },
   blueprintsPath: function() {
     return path.join(__dirname, 'blueprints');
   },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^6.6.0",
+    "ember-cli-version-checker": "^2.1.0",
     "jquery-colpick": "^3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Add an ember-cli version check to make sure only ember-cli >= 2.15.0 is used with this addon. As we've dropped Bower support, using `app.import` to import assets from `node_modules` was only introduced in ember-cli 2.15.0.

Ember CLI 2.14.2
![image](https://user-images.githubusercontent.com/685034/36002066-add08c9c-0d20-11e8-87b2-4c3b02f25d3d.png)

Ember CLI 2.15.0
![image](https://user-images.githubusercontent.com/685034/36002204-36e03b72-0d21-11e8-9d15-916a828eac91.png)
