### PR TITLE
use this._colpick.colpickDestroy() in _tearDownColpick

### DIFF
--- a/addon/mixins/col-pick.js
+++ b/addon/mixins/col-pick.js
@@ -109,7 +109,7 @@ export default Mixin.create( {
   _tearDownColpick: function() {
     if (this._colpick) {
       if (!this.isDestroying) {
-        this.popup().remove();
+        this._colpick.colpickDestroy();
       }
       this._colpick = undefined;
     }


### PR DESCRIPTION
When the component is destroyed programatically (computed property, websocket update) the colpick elements are removed form the DOM, but the $('html') mousedown event is still bound.
`this._colpick.colpickDestroy()` already removes the DOM element, so using it just makes sense.
Coupled with https://github.com/mrgrain/colpick/pull/1 `colpickDestroy` will also unbind the mousedown event set on $('html').

I had to override `_tearDownColpick` in my code to avoid this nasty issue : 
```
  _tearDownColpick: function() {
    if (this._colpick) {
      if (!this.isDestroying) {
        this._colpick.colpickHide();
        this._colpick.colpickDestroy();
      }
      this._colpick = undefined;
    }
  }
```

With this PR, the override isn't needed.