### PR TITLE
Feature/value change action

### DIFF
--- a/addon/mixins/col-pick.js
+++ b/addon/mixins/col-pick.js
@@ -1,3 +1,5 @@
+/* eslint-disable ember/closure-actions */
+
 import $ from 'jquery';
 import { isPresent } from '@ember/utils';
 import Mixin from '@ember/object/mixin';
@@ -49,6 +51,7 @@ export default Mixin.create( {
   }),
 
   _setupColpick: function() {
+    var instance = this;
     var layout = this.get('colpickLayout');
     var colorScheme = this.get('colorScheme');
 
@@ -58,19 +61,18 @@ export default Mixin.create( {
         colorScheme: colorScheme,
         submit: 0,
         flat: this.get('flat'),
-        onChange: bind(this, function(hsb, hex) {
+        onChange: bind(this, function(hsb, hex, rgb, el, bySetColor) {
           if (this.get('useHashtag')) {
             hex = '#' + hex;
           }
 
           this.set('previewValue', hex);
 
-          if (this._isValidPreviewValue()) {
-            this.set('value', hex);
+          if (this._isValidPreviewValue() && !bySetColor) {
+            this._setColpickValue(hex);
           }
         }),
         onHide: bind(this, function(){
-          // eslint-disable-next-line ember/closure-actions
           this.sendAction('onHide');
         })
       });
@@ -79,6 +81,7 @@ export default Mixin.create( {
         var hexInputVal = this.value;
         if (hexInputVal.length === 6) {
           colpick.colpickSetColor(hexInputVal);
+          instance._setColpickValue(hexInputVal);
         }
       });
 
@@ -104,6 +107,11 @@ export default Mixin.create( {
   didInsertElement: function () {
     this._super();
     this._setupColpick();
+  },
+
+  _setColpickValue: function(value) {
+    this.set('value', value);
+    this.sendAction('onChange', value);
   },
 
   _tearDownColpick: function() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-colpick",
-  "version": "0.6.2",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR makes sure an onChange event (https://github.com/yapplabs/ember-colpick/pull/18) is sent & the value is set only of a user interaction caused the value to change (see: https://github.com/mrgrain/colpick **bySetColor** flag).

This also allows the component to be used in a data-down/actions-up way (without 2-way binding on _value_).
```
// components/col-pick-button.js
import Component from '@ember/component';
import ColPickMixin from 'ember-colpick/mixins/col-pick';

export default Component.extend(ColPickMixin, {
  flat: false
});
```

```
{{!-- hello.hbs --}}
{{#col-pick-button value=(unbound record.color) onChange=(action 'colorUpdated' record)}}
  Hello
{{/col-pick-button}}
```

Without this, the component is exposed to some unpredictable 2-way binding side-effects; combine this and WebSocket updates and you may get XMas tree lights on your production app 😅.


I'm running this branch in production BTW:

![3a78115eb1231c015ce9b58be77f1ef2](https://user-images.githubusercontent.com/1762666/38640844-6e00d636-3da3-11e8-9e0e-a7a055452303.gif)
