### PR TITLE
Fix how vendored assets are imported

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,13 +17,13 @@ module.exports = {
   blueprintsPath: function () {
     return path.join(__dirname, 'blueprints');
   },
-  included: function colpick_included() {
+  included: function colpick_included(app) {
     this._super.included.apply(this, arguments);
     if (!process.env.EMBER_CLI_FASTBOOT) {
       var colpickPath = path.join('vendor', 'jquery-colpick');
 
-      this.app.import(path.join(colpickPath, 'colpick.js'));
-      this.app.import(path.join(colpickPath, 'colpick.css'));
+      app.import(path.join(colpickPath, 'colpick.js'));
+      app.import(path.join(colpickPath, 'colpick.css'));
     }
   },
 };


### PR DESCRIPTION
`this.app` is only available for addons who are a direct dependency of the consuming app. ([docs](https://ember-cli.com/api/classes/addon#props_app))

In the case where the addon is a dependency of another addon, this.app is not defined.

However, the `included` function is passed a `parent` which is either the consuming app or the parent addon. ([docs](https://ember-cli.com/api/classes/addon#method_included))

Seeing as we use ember-colpick as a dependency of an addon which is itself a dependency of the app, `this.app` fails and we need to use `app` instead. We made this patch to get around this.

Would you consider merging this in to the mainline branch so we can remove our fork?