### PR TITLE
Add correct re-exports of components to future-proof for embroider

### DIFF
--- a/addon/components/col-pick-input.js
+++ b/addon/components/col-pick-input.js
@@ -1,0 +1,8 @@
+/* eslint-disable ember/no-classic-classes */
+/* eslint-disable ember/no-mixins */
+import { TextField } from '@ember/legacy-built-in-components';
+import ColPickMixin from 'ember-colpick/mixins/col-pick';
+
+export default TextField.extend(ColPickMixin, {
+  flat: false,
+});

--- a/addon/components/col-pick.js
+++ b/addon/components/col-pick.js
@@ -1,0 +1,6 @@
+/* eslint-disable ember/no-mixins */
+/* eslint-disable ember/no-classic-components */
+import Component from '@ember/component';
+import ColPickMixin from 'ember-colpick/mixins/col-pick';
+
+export default Component.extend(ColPickMixin);

--- a/app/components/col-pick-input.js
+++ b/app/components/col-pick-input.js
@@ -1,8 +1,1 @@
-/* eslint-disable ember/no-classic-classes */
-/* eslint-disable ember/no-mixins */
-import { TextField } from '@ember/legacy-built-in-components';
-import ColPickMixin from 'ember-colpick/mixins/col-pick';
-
-export default TextField.extend(ColPickMixin, {
-  flat: false,
-});
+export { default } from 'ember-colpick/components/col-pick-input';

--- a/app/components/col-pick.js
+++ b/app/components/col-pick.js
@@ -1,6 +1,1 @@
-/* eslint-disable ember/no-mixins */
-/* eslint-disable ember/no-classic-components */
-import Component from '@ember/component';
-import ColPickMixin from 'ember-colpick/mixins/col-pick';
-
-export default Component.extend(ColPickMixin);
+export { default } from 'ember-colpick/components/col-pick';


### PR DESCRIPTION
Components that should be available in the consuming app's namespace should be defined in the addon's `addon` directory and re-exported from the `app` directory. This will be needed in an Embroider world.

This PR rectifies this.